### PR TITLE
Define initial subprojects of pod-daq-analzer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# pod-daq-analyzer
+
+This repo contains code to support the logging of data acquisition packets
+and their analysis.
+
+## Subprojects
+
+The major subprojects (subdirectories are):
+
+  * pi3-buildroot - Buildroot configuration for Raspberry Pi 3,
+    which serves as the host data logger running "tcpdump".
+    The "tcpdump" utility may be replaced later by a real-time logger
+    which is tailored to specific needs of the overall project.
+  * capextract - Extraction of data from captured packets and
+    conversion to CSV.  This is dependent on the packet definitions for
+    each of the reporting controls or sensors.
+    The CSV conversion may be done on the RaspPi3, or the data may
+    be downloaded after flight to a laptop or desktop and converted
+    there.
+  * daqparse - Interpretation of CSV data, possibly in Python and
+    Bokeh.  This is expected to run on laptop or desktop.
+
+A logger other than "tcpdump" may eventually be created.  In that
+case, there may be another project:
+
+  * logger - listens for specific network traffic, and stores it
+    into log files, for later processing.  Alternatively, selected
+    packets may be forwarded to a capextract thread/process for
+    immediate consumption.
+
+## Possible use cases
+
+The current architecture assumes real-time capture and logging of data
+packets by "tcpdump"; subsequent extraction of data and conversion to
+CSV depend on the logging media (microSD card) being removed from
+the pod in non-real-time.
+
+There are possible variations to this.  All start with:
+
+  * Real-time capture and logging of packets in a 'capture thread'.
+
+The capture thread may filter certain data channels for:
+
+  * immediate conversion to CSV.
+  * collection of channel min/max values for periodic transmission
+    to a ground station.
+

--- a/capextract/Notes.md
+++ b/capextract/Notes.md
@@ -1,0 +1,29 @@
+# capextract - extract data from captured packets
+
+This subproject is intended to extract the payload portion of captured IPv4
+(usually UDP) packets, and convert them into CSV files which can later be
+viewed by analysis programs.
+
+## Requirements
+
+The packets are currently captured (logged) by Unix/Linux "tcpdump", and
+are thus stored with corresponding "libpcap" meta-data.  The extractor(s)
+will need to parse beyond the meta-data, IPv4, and other protocol layers to
+get at the data acquired through DAQ processes.
+
+The extractor will need to recognize the type of data, according to an
+early field in the payload, and make the data available to the converter.
+The extractor acts as the interface between the host data logger
+(currrently "tcpdump") and application-specific data.  It should be
+possible to change out the data logger without impacting the
+downstream services, e.g., the converter.
+
+The converter interprets the data according to DAQ configuration files,
+resulting in CSV files.  The converter may run on the same system as the
+data logger or on machine external to the pod, e.g., a laptop or desktop
+machine.
+
+## References
+
+  * pcap-savefile -
+    http://www.tcpdump.org/manpages/pcap-savefile.5.html

--- a/daqparse/Notes.md
+++ b/daqparse/Notes.md
@@ -1,0 +1,9 @@
+# daqparse - interpret CSV data from DAQ
+
+DAQ data is expected to be in regular CSV form, with a first line providing
+column leaders.
+
+The tools for interpreting the data are expected to run on a laptop or
+desktop machine, not the pod computers.  Scripts are envisioned in a
+combination of Python and NumPy-based visualization such as Bokeh.
+

--- a/pi3-buildroot/Notes.md
+++ b/pi3-buildroot/Notes.md
@@ -1,0 +1,8 @@
+# pi3-buildroot
+
+This subproject specifies the configuration and other components
+needed to create a Buildroot image for the Raspberry Pi 3.
+
+## References
+
+  * Buildroot - https://buildroot.org/


### PR DESCRIPTION
This commit defines the initial subproject structure, adding them to branch 'dev'.  The subdiretories are currently empty, expects for a "Notes.md" file to describe what the expectations are for that subproject.